### PR TITLE
update the permissions of the files to get updated later

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN chmod 755 /home/codeuser/custom-strings.json
 # Switch back to codeuser
 USER codeuser
 RUN mkdir -p /home/codeuser/Documents/Cline/Rules
-COPY clinerules.md /home/codeuser/Documents/Cline/Rules/clinerules.md
+COPY --chown=codeuser:codeuser clinerules.md /home/codeuser/Documents/Cline/Rules/clinerules.md
 WORKDIR /home/codeuser/project
 
 EXPOSE 8080


### PR DESCRIPTION
While copying the file clinerules.md file inside code-server container, the root user is being used and once the container is running, the codeuser user is being used, because of this, the update operation on this file is failing. 

```
$ ls -la /home/codeuser/Documents/Cline/Rules/clinerules.md
-rw-r--r--. 1 root root 1731 Sep 18 19:58 /home/codeuser/Documents/Cline/Rules/clinerules.md
$
$ whoami
codeuser
$ id
uid=1000(codeuser) gid=1000(codeuser) groups=1000(codeuser)
$ test -w /home/codeuser/Documents/Cline/Rules/clinerules.md && echo "File is writable" || echo "File is NOT writable"
File is NOT writable
```
Giving the ownership to the codeuser user so that the file can be edited. 
