### PR TITLE
feat(docker): tag ECR images with latest on release

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -268,6 +268,7 @@ jobs:
           images: ${{ env.ecr_docker_images }}
           tags: |
             type=raw,value=${{ steps.docker-tag.outputs.tag }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
       - name: docker arm64 meta
         id: arm64_meta
         uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
@@ -275,6 +276,7 @@ jobs:
           images: ${{ env.ecr_docker_images }}
           tags: |
             type=raw,value=${{ steps.docker-tag.outputs.tag }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
           flavor: |
             suffix=-${{ env.arch_arm64 }},onlatest=true
       - name: docker amd64 meta
@@ -284,6 +286,7 @@ jobs:
           images: ${{ env.ecr_docker_images }}
           tags: |
             type=raw,value=${{ steps.docker-tag.outputs.tag }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
           flavor: |
             suffix=-${{ env.arch_amd64 }},onlatest=true
 


### PR DESCRIPTION
## Why

CI pipelines that consume the code-server Docker image need to always pull the most recent release. Without a `latest` tag, every pipeline must be updated with the exact version tag on each release. Tagging with `latest` lets CI jobs use a stable reference that always points to the newest release.

## Summary
- Adds a `latest` tag to the three ECR Docker metadata steps (`docker meta`, `docker arm64 meta`, `docker amd64 meta`) in the `docker-metadata-ecr` job
- The tag is conditionally enabled only when `github.event_name == 'release'`, so PR and manual dispatch builds are unaffected
- The existing `docker-manifest-ecr` job automatically creates a multi-arch `latest` manifest from the arch-specific `latest-arm64` and `latest-amd64` tags

## Test plan
- [ ] Open this PR — verify the PR build produces only `pr-<N>` tags (no `latest`)
- [ ] Publish a release — confirm ECR image has both `v<VERSION>` and `latest` tags
- [ ] Verify `docker pull 422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/profiles-code-server:latest` returns the multi-arch image

Resolves PRO-5596

🤖 Generated with [Claude Code](https://claude.com/claude-code)