### PR TITLE
fix(sec-86): harden iframe postMessage to trusted parent origins

### DIFF
--- a/patches/harden-iframe-postmessage.diff
+++ b/patches/harden-iframe-postmessage.diff
@@ -1,0 +1,76 @@
+Index: code-server/lib/vscode/src/vs/base/common/product.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/base/common/product.ts
++++ code-server/lib/vscode/src/vs/base/common/product.ts
+@@ -57,6 +57,7 @@ export type ExtensionVirtualWorkspaceSup
+ 
+ export interface IProductConfiguration {
+ 	readonly codeServerVersion?: string
++	readonly codeServerParentOrigins?: readonly string[]
+ 	readonly rootEndpoint?: string
+ 	readonly updateEndpoint?: string
+ 	readonly logoutEndpoint?: string
+Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/server/node/webClientServer.ts
++++ code-server/lib/vscode/src/vs/server/node/webClientServer.ts
+@@ -346,8 +346,14 @@ export class WebClientServer {
+ 			linkProtectionTrustedDomains.push(...this._productService.linkProtectionTrustedDomains);
+ 		}
+ 
++		const codeServerParentOrigins: string[] = (process.env.CS_ALLOWED_ORIGINS ?? '')
++			.split(',')
++			.map(o => o.trim())
++			.filter(o => o.length > 0);
++
+ 		const productConfiguration: Partial<Mutable<IProductConfiguration>> = {
+ 			codeServerVersion: this._productService.codeServerVersion,
++			codeServerParentOrigins,
+ 			rootEndpoint: rootBase,
+ 			updateEndpoint: !this._environmentService.args['disable-update-check'] ? rootBase + '/update/check' : undefined,
+ 			logoutEndpoint: this._environmentService.args['auth'] && this._environmentService.args['auth'] !== "none" ? rootBase + '/logout' : undefined,
+Index: code-server/lib/vscode/src/vs/workbench/browser/client.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/workbench/browser/client.ts
++++ code-server/lib/vscode/src/vs/workbench/browser/client.ts
+@@ -22,14 +22,28 @@ export class CodeServerClient extends Di
+ 		const event = new CustomEvent('ide-ready');
+ 		window.dispatchEvent(event);
+ 
+-		if (parent) {
+-			// Tell the parent loading has completed.
+-			parent.postMessage({ event: 'loaded' }, '*');
++		const trustedParentOrigins = this.productService.codeServerParentOrigins ?? [];
++		if (parent && parent !== window && trustedParentOrigins.length > 0) {
++			// Tell the parent loading has completed. Post to each trusted origin
++			// individually rather than using a wildcard ('*') so the message is
++			// not delivered to an unexpected embedder.
++			for (const origin of trustedParentOrigins) {
++				parent.postMessage({ event: 'loaded' }, origin);
++			}
+ 
+ 			// Proxy or stop proxing events as requested by the parent.
+ 			const listeners = new Map<string, (event: Event) => void>();
+ 
+ 			window.addEventListener('message', parentEvent => {
++				// Reject messages from any window that is not our direct parent
++				// or from an origin we do not explicitly trust.
++				if (parentEvent.source !== parent) {
++					return;
++				}
++				if (!trustedParentOrigins.includes(parentEvent.origin)) {
++					return;
++				}
++
+ 				const eventName = parentEvent.data.bind || parentEvent.data.unbind;
+ 				if (eventName) {
+ 					const oldListener = listeners.get(eventName);
+@@ -45,7 +59,7 @@ export class CodeServerClient extends Di
+ 								event: parentEvent.data.event,
+ 								[parentEvent.data.prop]: event[parentEvent.data.prop as keyof Event],
+ 							},
+-							window.location.origin,
++							parentEvent.origin,
+ 						);
+ 					};
+ 					listeners.set(parentEvent.data.bind, listener);

--- a/patches/series
+++ b/patches/series
@@ -35,3 +35,4 @@ auxiliary-bar-rudderstack-icon.diff
 cline-seed-storage.diff
 hide-scm-actions.diff
 hide-scm-title-actions.diff
+harden-iframe-postmessage.diff


### PR DESCRIPTION
## Summary

- Replaces wildcard `'*'` `postMessage` target in the code-server iframe client with an explicit allowlist sourced from `CS_ALLOWED_ORIGINS` (SEC-86).
- Guards the inbound `message` listener in `client.ts` by both `parentEvent.source === parent` (window identity) and an origin allowlist (SEC-87).
- Fails closed: if the allowlist is empty, no outbound `postMessage` is sent and no inbound messages are processed.
- Also fixes a latent bug where the outbound "event proxy" re-post used `window.location.origin` — iframe and parent live at different origins, so the browser was silently dropping those messages. Now targets the validated `parentEvent.origin`.

## Mechanism

New quilt patch `patches/harden-iframe-postmessage.diff`:

- `lib/vscode/src/vs/base/common/product.ts` — adds `codeServerParentOrigins?: readonly string[]` to `IProductConfiguration`.
- `lib/vscode/src/vs/server/node/webClientServer.ts` — parses `process.env.CS_ALLOWED_ORIGINS` and injects into the workbench `productConfiguration` (mirrors the existing `VSCODE_PROXY_URI` env-var pattern a few lines above).
- `lib/vscode/src/vs/workbench/browser/client.ts` — origin-guarded outbound + inbound messaging.

## Linear

Fixes SEC-86
Fixes SEC-87

## Test plan

- [ ] `quilt push -a` applies the full stack cleanly (CI `build-vscode.yaml` gate).
- [ ] Manual: code-server built with this patch, embedded in webapp with `CS_ALLOWED_ORIGINS=https://app.dev.rudderlabs.com`, verify:
  - [ ] `loaded` postMessage reaches the webapp iframe parent on startup.
  - [ ] Messages sent from a non-allowlisted origin (simulated via a second iframe) are ignored.
  - [ ] With `CS_ALLOWED_ORIGINS` empty, no outbound `postMessage` is fired and no inbound messages are processed.
- [ ] Release flow: after release-please PR merges and a new ECR image is built, bump `CodeServerImageName` in rudder-devops to verify embedding still works in dev before closing SEC-86 / SEC-87.