### PR TITLE
chore(vuln): remediate template-injection findings (SEC-251)

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -70,14 +70,17 @@ jobs:
 
       - name: Get and set VERSION
         id: version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             VERSION="0.0.0-pr.${{ github.event.pull_request.number }}"
           elif [ "${{ github.event_name }}" = "release" ]; then
-            TAG="${{ github.event.release.tag_name }}"
+            TAG="$RELEASE_TAG"
             VERSION="${TAG#v}"
           else
-            TAG="${{ inputs.version }}"
+            TAG="$INPUT_VERSION"
             VERSION="${TAG#v}"
           fi
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
@@ -252,13 +255,16 @@ jobs:
 
       - name: Determine Docker tag
         id: docker-tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "tag=pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" = "release" ]; then
-            echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+            echo "tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
           else
-            echo "tag=${{ inputs.version }}" >> $GITHUB_OUTPUT
+            echo "tag=$INPUT_VERSION" >> $GITHUB_OUTPUT
           fi
 
       - name: docker meta
@@ -482,11 +488,14 @@ jobs:
 
       - name: Determine tag name
         id: tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           if [ "${{ github.event_name }}" = "release" ]; then
-            echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+            echo "tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
           else
-            echo "tag=${{ inputs.version }}" >> $GITHUB_OUTPUT
+            echo "tag=$INPUT_VERSION" >> $GITHUB_OUTPUT
           fi
 
       - name: Upload Release Assets

--- a/.github/workflows/update-cline.yml
+++ b/.github/workflows/update-cline.yml
@@ -29,13 +29,17 @@ jobs:
 
       - name: Set version variables
         id: vars
+        env:
+          CLIENT_PAYLOAD_VERSION: ${{ github.event.client_payload.version }}
+          CLIENT_PAYLOAD_TAG: ${{ github.event.client_payload.tag }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            VERSION="${{ github.event.client_payload.version }}"
-            TAG="${{ github.event.client_payload.tag }}"
+            VERSION="$CLIENT_PAYLOAD_VERSION"
+            TAG="$CLIENT_PAYLOAD_TAG"
           else
-            VERSION="${{ github.event.inputs.version }}"
-            TAG="v${{ github.event.inputs.version }}"
+            VERSION="$INPUT_VERSION"
+            TAG="v$INPUT_VERSION"
           fi
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Remediates `zizmor/template-injection` findings in this repo as part of the org-wide remediation tracked in [SEC-251](https://linear.app/rudderstack/issue/SEC-251) (parent: [SEC-162](https://linear.app/rudderstack/issue/SEC-162)).

## Verification

- actionlint (syntax+expressions): green before, green after
- zizmor: all targeted findings absent post-fix; no new findings introduced
- Edits scoped to `.github/` only; no reformatting / drive-by changes

## Test plan

- [ ] CI green
- [ ] No release-tagging or workflow-trigger regression (SEC-198 class)
