### PR TITLE
feat: install Go 1.24.2 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,16 @@ RUN apt-get update && \
 
 
 # ============================================
+# Install Go
+# ============================================
+ARG GO_VERSION=1.24.2
+RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" \
+      -o /tmp/go.tar.gz && \
+    tar -C /usr/local -xzf /tmp/go.tar.gz && \
+    rm /tmp/go.tar.gz
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# ============================================
 # RESTRICTED SHELL SECURITY (lshell)
 # ============================================
 # lshell (limited-shell) restricts terminal commands to a whitelist.


### PR DESCRIPTION
## Summary
- Adds Go 1.24.2 installation to the root Dockerfile using the official tarball from go.dev
- Uses the existing `TARGETARCH` build arg to support multi-architecture builds (amd64/arm64)
- Go version is configurable via `GO_VERSION` build arg

## Test plan
- [ ] Build the Docker image and verify `go version` returns `go1.24.2`
- [ ] Verify the image builds for both amd64 and arm64 targets
- [ ] Confirm existing functionality (code-server, lshell, Python) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)