### PR TITLE
fix(sec-89): unify CORS allowlist under CS_ALLOWED_ORIGINS

### DIFF
--- a/src/node/routes/index.ts
+++ b/src/node/routes/index.ts
@@ -7,7 +7,7 @@ import * as tls from "tls"
 import { Disposable } from "../../common/emitter"
 import { HttpCode, HttpError } from "../../common/http"
 import { plural } from "../../common/util"
-import { getAllowedOrigins } from "../allowedOrigins"
+import { getAllowedOrigins, isOriginAllowed } from "../allowedOrigins"
 import { App } from "../app"
 import { AuthType, DefaultedArgs } from "../cli"
 import { commit, rootPath } from "../constants"
@@ -81,17 +81,7 @@ export const register = async (app: App, args: DefaultedArgs): Promise<Disposabl
   app.router.use(common)
   app.wsRouter.use(common)
 
-  // Add CORS header to all responses
-  app.router.use((req, res, next) => {
-    const origin = req.headers.origin
-    const allowedOrigins = ["https://app.rudderstack.com", "https://app.dev.rudderlabs.com"]
-
-    if (origin && (allowedOrigins.includes(origin) || origin.match(/^https?:\/\/localhost(:\d+)?$/))) {
-      res.setHeader("Access-Control-Allow-Origin", origin)
-    }
-
-    next()
-  })
+  app.router.use(corsMiddleware())
 
   app.router.use(frameAncestorsMiddleware())
 
@@ -206,6 +196,21 @@ export function frameAncestorsMiddleware(): express.RequestHandler {
   const value = allowed.length > 0 ? allowed.join(" ") : "'none'"
   return (_req, res, next) => {
     res.setHeader("Content-Security-Policy", `frame-ancestors ${value}`)
+    next()
+  }
+}
+
+/**
+ * Reflect `Access-Control-Allow-Origin` only for origins listed in
+ * `CS_ALLOWED_ORIGINS`. Single source of truth with `frame-ancestors`.
+ */
+export function corsMiddleware(): express.RequestHandler {
+  return (req, res, next) => {
+    const origin = req.headers.origin
+    if (origin && isOriginAllowed(origin)) {
+      res.setHeader("Access-Control-Allow-Origin", origin)
+      res.setHeader("Vary", "Origin")
+    }
     next()
   }
 }

--- a/test/unit/node/routes/cors.test.ts
+++ b/test/unit/node/routes/cors.test.ts
@@ -1,0 +1,67 @@
+import express from "express"
+
+jest.mock("../../../../src/node/allowedOrigins", () => ({
+  getAllowedOrigins: jest.fn(() => []),
+  getAllowedHosts: jest.fn(() => []),
+  isOriginAllowed: jest.fn(() => false),
+}))
+
+import { isOriginAllowed } from "../../../../src/node/allowedOrigins"
+import { corsMiddleware } from "../../../../src/node/routes/index"
+
+describe("corsMiddleware", () => {
+  afterEach(() => {
+    ;(isOriginAllowed as jest.Mock).mockReset()
+  })
+
+  function invoke(originHeader?: string): {
+    aclHeader: string | undefined
+    varyHeader: string | undefined
+    nextCalled: boolean
+  } {
+    const headers: Record<string, string> = {}
+    const res = {
+      setHeader: jest.fn((name: string, value: string) => {
+        headers[name] = value
+      }),
+    } as unknown as express.Response
+    const req = { headers: originHeader ? { origin: originHeader } : {} } as unknown as express.Request
+    const next = jest.fn()
+    corsMiddleware()(req, res, next)
+    return {
+      aclHeader: headers["Access-Control-Allow-Origin"],
+      varyHeader: headers["Vary"],
+      nextCalled: next.mock.calls.length === 1,
+    }
+  }
+
+  it("does not set ACAO when no Origin header is present", () => {
+    ;(isOriginAllowed as jest.Mock).mockReturnValue(true)
+    const { aclHeader, varyHeader, nextCalled } = invoke()
+    expect(aclHeader).toBeUndefined()
+    expect(varyHeader).toBeUndefined()
+    expect(nextCalled).toBe(true)
+  })
+
+  it("does not set ACAO when origin is not in CS_ALLOWED_ORIGINS", () => {
+    ;(isOriginAllowed as jest.Mock).mockReturnValue(false)
+    const { aclHeader, varyHeader } = invoke("https://app.dev.rudderlabs.com")
+    expect(aclHeader).toBeUndefined()
+    expect(varyHeader).toBeUndefined()
+    expect(isOriginAllowed).toHaveBeenCalledWith("https://app.dev.rudderlabs.com")
+  })
+
+  it("does not set ACAO for localhost when not explicitly allowed", () => {
+    ;(isOriginAllowed as jest.Mock).mockReturnValue(false)
+    const { aclHeader } = invoke("http://localhost:8080")
+    expect(aclHeader).toBeUndefined()
+  })
+
+  it("reflects ACAO and sets Vary when origin is allowed", () => {
+    ;(isOriginAllowed as jest.Mock).mockReturnValue(true)
+    const { aclHeader, varyHeader, nextCalled } = invoke("https://app.rudderstack.com")
+    expect(aclHeader).toBe("https://app.rudderstack.com")
+    expect(varyHeader).toBe("Origin")
+    expect(nextCalled).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- Drive `Access-Control-Allow-Origin` from `CS_ALLOWED_ORIGINS` (single source of truth with `frame-ancestors`).
- Remove hardcoded origin list and unconditional `localhost` regex.
- Add `Vary: Origin` on reflected responses.

Ref: SEC-89.

## Test plan

- [ ] `npm run test:unit -- test/unit/node/routes/cors.test.ts test/unit/node/routes/csp.test.ts test/unit/node/allowedOrigins.test.ts`
- [ ] In a dev overlay with `CS_ALLOWED_ORIGINS` containing the dev webapp, verify `OPTIONS` preflight from the dev webapp succeeds.
- [ ] In a prod-like overlay, `curl -H "Origin: https://app.dev.rudderlabs.com" …` returns no `Access-Control-Allow-Origin`.
- [ ] Same probe with `Origin: http://localhost:8080` returns no `Access-Control-Allow-Origin`.