### PR TITLE
chore: bump profiles-mlcorelib to 0.9.6 and profiles-rudderstack to 0.25.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 awscli==1.42.59
-profiles-mlcorelib==0.9.3
-profiles-rudderstack==0.25.2
+profiles-mlcorelib==0.9.6
+profiles-rudderstack==0.25.5


### PR DESCRIPTION
## Summary
- Bump `profiles-mlcorelib` from 0.9.3 to 0.9.6
- Bump `profiles-rudderstack` from 0.25.2 to 0.25.5

## Test plan
- [ ] Verify Docker image builds successfully with updated dependencies
- [ ] Smoke-test profiles workflows in the code-server environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)