### PR TITLE
fix: use heredoc syntax for multi-line GITHUB_OUTPUT in docker build

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -396,11 +396,23 @@ jobs:
         id: arch-meta
         run: |
           if [ "${{ matrix.arch }}" = "arm64" ]; then
-            echo "tags=${{ needs.docker-metadata-ecr.outputs.arm64_tags }}" >> $GITHUB_OUTPUT
-            echo "labels=${{ needs.docker-metadata-ecr.outputs.arm64_labels }}" >> $GITHUB_OUTPUT
+            {
+              echo "tags<<TAGS_EOF"
+              echo "${{ needs.docker-metadata-ecr.outputs.arm64_tags }}"
+              echo "TAGS_EOF"
+              echo "labels<<LABELS_EOF"
+              echo "${{ needs.docker-metadata-ecr.outputs.arm64_labels }}"
+              echo "LABELS_EOF"
+            } >> $GITHUB_OUTPUT
           else
-            echo "tags=${{ needs.docker-metadata-ecr.outputs.amd64_tags }}" >> $GITHUB_OUTPUT
-            echo "labels=${{ needs.docker-metadata-ecr.outputs.amd64_labels }}" >> $GITHUB_OUTPUT
+            {
+              echo "tags<<TAGS_EOF"
+              echo "${{ needs.docker-metadata-ecr.outputs.amd64_tags }}"
+              echo "TAGS_EOF"
+              echo "labels<<LABELS_EOF"
+              echo "${{ needs.docker-metadata-ecr.outputs.amd64_labels }}"
+              echo "LABELS_EOF"
+            } >> $GITHUB_OUTPUT
           fi
 
       - name: docker build


### PR DESCRIPTION
## Summary
- Fixes the `docker-build-ecr` job failure on release builds caused by multi-line values written to `$GITHUB_OUTPUT` using simple `echo "key=value"` syntax
- On release events, `docker/metadata-action` produces two tags (versioned + `latest`), resulting in a multi-line string. The second line lacks a `key=` prefix, causing GitHub Actions to reject it with: `Invalid format '...profiles-code-server:latest-arm64'`
- Switches to the heredoc delimiter syntax (`<<EOF`) which is the standard way to handle multi-line output variables in GitHub Actions

## Test plan
- [ ] Trigger a release build and verify the `docker-build-ecr` job passes for both arm64 and amd64
- [ ] Verify the `docker-manifest-ecr` multi-arch manifest is created successfully with both versioned and `latest` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)