### PR TITLE
fix(sec-90): remove '*' wildcard bypass from authenticateOrigin

### DIFF
--- a/src/node/http.ts
+++ b/src/node/http.ts
@@ -390,7 +390,7 @@ export function authenticateOrigin(req: express.Request): void {
   }
 
   const trustedOrigins = req.args["trusted-origins"] || []
-  if (trustedOrigins.includes(origin) || trustedOrigins.includes("*")) {
+  if (trustedOrigins.includes(origin)) {
     return
   }
 

--- a/test/unit/node/http.test.ts
+++ b/test/unit/node/http.test.ts
@@ -80,6 +80,30 @@ describe("http", () => {
         })
       })
     })
+
+    it("should not treat '*' in trusted-origins as a wildcard bypass", () => {
+      const req = getMockReq({
+        originalUrl: "localhost:8080",
+        headers: {
+          origin: "http://evil.example.com",
+          host: "localhost:8080",
+        },
+        args: { "trusted-origins": ["*"] },
+      })
+      expect(() => http.authenticateOrigin(req)).toThrow("does not match")
+    })
+
+    it("should accept an exact match in trusted-origins", () => {
+      const req = getMockReq({
+        originalUrl: "localhost:8080",
+        headers: {
+          origin: "http://trusted.example.com",
+          host: "localhost:8080",
+        },
+        args: { "trusted-origins": ["trusted.example.com"] },
+      })
+      expect(() => http.authenticateOrigin(req)).not.toThrow()
+    })
   })
 
   describe("constructRedirectPath", () => {


### PR DESCRIPTION
## Summary
- Drop the \`"*"\` short-circuit in \`authenticateOrigin()\` so the origin allowlist cannot be globally disabled.
- Behavior change: a literal \`*\` in \`--trusted-origins\` no longer bypasses the host-vs-origin check; only exact matches are honored.
- Fork divergence from upstream; required for the SEC-84/SEC-90 hardening track.

## Test plan
- [x] \`./test/node_modules/.bin/jest --testPathPattern "node/http.test"\` (49 passed)
- [ ] Verify no internal deployment relies on \`--trusted-origins=*\` (none expected — the flag has never been wired in our deployments; see sibling PR rudderlabs/rudder-sources#3349)