### PR TITLE
test: preview build with cline undici fix (PR #132 branch) — DO NOT MERGE

### DIFF
--- a/.cline-version
+++ b/.cline-version
@@ -1,1 +1,1 @@
-6.16.0
+fix/bump-undici-navigator-migration


### PR DESCRIPTION
## Summary

**Test PR — opened as draft, do not merge.** Pins `.cline-version` to the cline branch `fix/bump-undici-navigator-migration` (rudderlabs/cline#132) so build-docker.yaml produces a preview Docker image using a Cline build that has undici bumped to 6.25.0.

The cline PR fixes the \`PendingMigrationError: navigator is now a global in nodejs\` that crashes Cline activation on Node 22 (bundled in code-server v1.13.0+). See rudderlabs/cline#132 for full root-cause analysis.

The \`validate-cline-version.yml\` check will fail on this PR (it rejects branch refs at merge time) — that's by design. The image will still build under \`build-docker.yaml\` and produce a \`pr-XXX\` ECR tag we can deploy to profiles-qa for verification.

## Test plan
- [ ] \`build-docker.yaml\` succeeds and pushes \`422074288268.dkr.ecr.us-east-1.amazonaws.com/rudderstack/profiles-code-server:pr-XXX\` to ECR
- [ ] Update \`customer-objects/dev-rudder/profiles-qa.yaml\` in rudder-devops to point at \`pr-XXX\`
- [ ] Open code-server in profiles-qa: Cline panel renders without PendingMigrationError
- [ ] After verification: merge rudderlabs/cline#132, cut a 6.17.0 release, and open a real \`.cline-version\` bump PR (semver) to land in main

🤖 Generated with [Claude Code](https://claude.com/claude-code)