### PR TITLE
fix(http): require Origin header on WebSocket upgrades (SEC-88)

### DIFF
--- a/src/node/http.ts
+++ b/src/node/http.ts
@@ -375,11 +375,12 @@ export function ensureOrigin(req: express.Request, _?: express.Response, next?: 
  * Authenticate the request origin against the host.  Throw if invalid.
  */
 export function authenticateOrigin(req: express.Request): void {
-  // A missing origin probably means the source is non-browser.  Not sure we
-  // have a use case for this but let it through.
+  // Browsers always send Origin on WebSocket upgrades (RFC 6455 §10.2), and
+  // `ensureOrigin` only guards WS routes. A missing Origin therefore signals
+  // either a non-browser client or a forged upgrade attempt — reject both.
   const originRaw = getFirstHeader(req, "origin")
   if (!originRaw) {
-    return
+    throw new Error("missing Origin header")
   }
 
   let origin: string

--- a/test/unit/node/http.test.ts
+++ b/test/unit/node/http.test.ts
@@ -24,6 +24,12 @@ describe("http", () => {
       {
         origin: "",
         host: "",
+        expected: "missing Origin",
+      },
+      {
+        origin: "",
+        host: "localhost:8080",
+        expected: "missing Origin",
       },
       {
         origin: "http://localhost:8080",


### PR DESCRIPTION
## Summary

- Reject WS upgrades that arrive without an `Origin` header. Browsers always send it on WS upgrades (RFC 6455 §10.2); a missing value is either a non-browser client or a forged upgrade.
- `ensureOrigin` is only mounted on `wsRouter.ws` handlers, so HTTP API clients are unaffected.

## Test plan

- [x] Existing parameterised `authenticateOrigin` table updated; new case asserts missing Origin throws even when the host header is valid.
- [x] `jest test/unit/node/http.test.ts` — 53 passed, 0 failed.
- [ ] Smoke-test in dev: confirm the iframe still establishes WS to terminal/file-sync after deploy.

Closes [SEC-88](https://linear.app/rudderstack/issue/SEC-88).