### PR TITLE
feat(PRO-5526): open *_context.md as markdown preview on first workspace visit

### DIFF
--- a/patches/open-context-md-on-first-visit.diff
+++ b/patches/open-context-md-on-first-visit.diff
@@ -18,7 +18,7 @@ Index: code-server/lib/vscode/src/vs/workbench/contrib/codeServerProfiles/browse
 ===================================================================
 --- /dev/null
 +++ code-server/lib/vscode/src/vs/workbench/contrib/codeServerProfiles/browser/openContextMdContribution.ts
-@@ -0,0 +1,82 @@
+@@ -0,0 +1,101 @@
 +/* eslint-disable header/header */
 +/*---------------------------------------------------------------------------------------------
 + *  code-server: PRO-5526 open *_context.md as markdown preview on first workspace visit.
@@ -38,6 +38,7 @@ Index: code-server/lib/vscode/src/vs/workbench/contrib/codeServerProfiles/browse
 +import { IWorkspaceContextService, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
 +import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from '../../../common/contributions.js';
 +import { IEditorService } from '../../../services/editor/common/editorService.js';
++import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 +
 +const STORAGE_KEY = 'code-server.profilesContextMd.firstVisitHandled';
 +// Matches any file whose name ends with `_context.md` (case-insensitive).
@@ -51,6 +52,7 @@ Index: code-server/lib/vscode/src/vs/workbench/contrib/codeServerProfiles/browse
 +		@IFileService private readonly fileService: IFileService,
 +		@IEditorService private readonly editorService: IEditorService,
 +		@ICommandService private readonly commandService: ICommandService,
++		@IExtensionService private readonly extensionService: IExtensionService,
 +	) {
 +		super();
 +		// Fire and forget. We do not want to block workbench startup on file IO,
@@ -92,10 +94,27 @@ Index: code-server/lib/vscode/src/vs/workbench/contrib/codeServerProfiles/browse
 +		}
 +		const target = matches[0].resource;
 +
++		// `markdown.showPreview` lives in the markdown-language-features extension
++		// and is only registered after that extension activates. Its activation
++		// events (see `extensions/markdown-language-features/package.json`) are
++		// `onLanguage:markdown`, `onWebviewPanel:markdown.preview`, and a couple of
++		// `onCommand:markdown.api.*` — none of which fire from invoking
++		// `markdown.showPreview` itself. Without an explicit activation here the
++		// command is "not found" on cold-restore (no source editor is open yet, so
++		// `onLanguage:markdown` has not fired) and the preview never appears.
++		//
++		// `whenInstalledExtensionsRegistered()` waits for the extension registry
++		// to be populated; `activateByEvent('onLanguage:markdown')` then drives
++		// the markdown extension's `activate()` to run and register the command.
++		await this.extensionService.whenInstalledExtensionsRegistered();
++		await this.extensionService.activateByEvent('onLanguage:markdown');
++
 +		// Open as rendered preview only (no accompanying source editor) via the
 +		// built-in markdown-language-features command. Verified by reading
-+		// `extensions/markdown-language-features/src/commands/showPreview.ts`
-+		// and `extensions/markdown-language-features/package.json`.
++		// `extensions/markdown-language-features/src/commands/showPreview.ts`:
++		// when called with an explicit URI and no active text editor, the command
++		// opens the preview in `vscode.ViewColumn.One` without creating a source
++		// editor.
 +		await this.commandService.executeCommand('markdown.showPreview', target);
 +	}
 +}

--- a/patches/open-context-md-on-first-visit.diff
+++ b/patches/open-context-md-on-first-visit.diff
@@ -1,0 +1,115 @@
+Open *_context.md as markdown preview on first workspace visit (PRO-5526)
+
+On workbench restore in a fresh workspace that contains a top-level
+`*_context.md` file and has no persisted editors, open that file as a
+rendered markdown preview via the built-in `markdown.showPreview`
+command. A workspace-scoped `IStorageService` flag (key
+`code-server.profilesContextMd.firstVisitHandled`) gates the behavior
+so it only fires once per workspace; the flag is set before any async
+work so a failure mid-flight cannot retrigger the open.
+
+The implementation lives entirely in a new code-server-owned file
+under `contrib/codeServerProfiles/` and is registered through the
+modern `registerWorkbenchContribution2` API at
+`WorkbenchPhase.AfterRestored` so editors have already restored by
+the time we consult `IEditorService.editors`.
+
+Index: code-server/lib/vscode/src/vs/workbench/contrib/codeServerProfiles/browser/openContextMdContribution.ts
+===================================================================
+--- /dev/null
++++ code-server/lib/vscode/src/vs/workbench/contrib/codeServerProfiles/browser/openContextMdContribution.ts
+@@ -0,0 +1,82 @@
++/* eslint-disable header/header */
++/*---------------------------------------------------------------------------------------------
++ *  code-server: PRO-5526 open *_context.md as markdown preview on first workspace visit.
++ *
++ *  On workbench restore, if this workspace has never been handled before
++ *  and no editors are restored, find the alphabetically-first file at the
++ *  workspace root whose name matches `*_context.md` and open it as a
++ *  rendered markdown preview via the built-in markdown-language-features
++ *  command. A workspace-scoped storage flag ensures this only fires on the
++ *  very first visit. See https://linear.app/rudderstack/issue/PRO-5526.
++ *--------------------------------------------------------------------------------------------*/
++
++import { Disposable } from '../../../../base/common/lifecycle.js';
++import { ICommandService } from '../../../../platform/commands/common/commands.js';
++import { IFileService } from '../../../../platform/files/common/files.js';
++import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
++import { IWorkspaceContextService, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
++import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from '../../../common/contributions.js';
++import { IEditorService } from '../../../services/editor/common/editorService.js';
++
++const STORAGE_KEY = 'code-server.profilesContextMd.firstVisitHandled';
++// Matches any file whose name ends with `_context.md` (case-insensitive).
++const CONTEXT_MD_PATTERN = /_context\.md$/i;
++
++class OpenContextMdContribution extends Disposable implements IWorkbenchContribution {
++
++	constructor(
++		@IStorageService private readonly storageService: IStorageService,
++		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
++		@IFileService private readonly fileService: IFileService,
++		@IEditorService private readonly editorService: IEditorService,
++		@ICommandService private readonly commandService: ICommandService,
++	) {
++		super();
++		// Fire and forget. We do not want to block workbench startup on file IO,
++		// and any failure inside this handler must not propagate to the workbench.
++		this.maybeOpenContextMd().catch(err => console.error('[code-server PRO-5526] failed to open *_context.md preview:', err));
++	}
++
++	private async maybeOpenContextMd(): Promise<void> {
++		if (this.storageService.getBoolean(STORAGE_KEY, StorageScope.WORKSPACE, false)) {
++			return;
++		}
++
++		// Mark the flag immediately so we never re-trigger even if any downstream
++		// step (file resolve, command execution) fails or throws.
++		this.storageService.store(STORAGE_KEY, true, StorageScope.WORKSPACE, StorageTarget.USER);
++
++		// Honor restored editors: if the user has persisted tabs, do not force
++		// the preview open over them.
++		if (this.editorService.editors.length > 0) {
++			return;
++		}
++
++		// Profiles IDE only ever uses single-folder workspaces.
++		if (this.workspaceContextService.getWorkbenchState() !== WorkbenchState.FOLDER) {
++			return;
++		}
++		const folder = this.workspaceContextService.getWorkspace().folders[0];
++		if (!folder) {
++			return;
++		}
++
++		// List root-level entries and pick the alphabetically-first match.
++		const stat = await this.fileService.resolve(folder.uri);
++		const matches = (stat.children ?? [])
++			.filter(c => !c.isDirectory && CONTEXT_MD_PATTERN.test(c.name))
++			.sort((a, b) => a.name.localeCompare(b.name));
++		if (matches.length === 0) {
++			return;
++		}
++		const target = matches[0].resource;
++
++		// Open as rendered preview only (no accompanying source editor) via the
++		// built-in markdown-language-features command. Verified by reading
++		// `extensions/markdown-language-features/src/commands/showPreview.ts`
++		// and `extensions/markdown-language-features/package.json`.
++		await this.commandService.executeCommand('markdown.showPreview', target);
++	}
++}
++
++registerWorkbenchContribution2('workbench.contrib.codeServerProfiles.openContextMd', OpenContextMdContribution, WorkbenchPhase.AfterRestored);
+Index: code-server/lib/vscode/src/vs/workbench/workbench.common.main.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/workbench/workbench.common.main.ts
++++ code-server/lib/vscode/src/vs/workbench/workbench.common.main.ts
+@@ -426,4 +426,7 @@ import './contrib/rudderstack/browser/ru
+ // code-server: PRO-5528 RudderStack tab status bar entry
+ import './contrib/codeServerProfiles/browser/rudderstackTabStatusBar.contribution.js';
+ 
++// code-server: PRO-5526 open *_context.md as markdown preview on first visit
++import './contrib/codeServerProfiles/browser/openContextMdContribution.js';
++
+ //#endregion

--- a/patches/series
+++ b/patches/series
@@ -43,3 +43,4 @@ status-bar-rudderstack-tab.diff
 hide-stock-vscode-defaults.diff
 editor-tab-strip.diff
 correct-tab-active-bg.diff
+open-context-md-on-first-visit.diff


### PR DESCRIPTION
## Summary

Implements [PRO-5526](https://linear.app/rudderstack/issue/PRO-5526) — on a fresh visit to a workspace, automatically opens a top-level `*_context.md` file as a rendered markdown preview, matching the Figma "Default state" ([node 101:2943](https://www.figma.com/design/SDpW683dzIqtXeGsAyQqyt/Profiles-%7C-Feb-26th-2026?node-id=101-2943)). On subsequent visits the IDE resumes whatever tabs the user had open — the auto-preview never re-triggers.

This is **stacked on top of [#210](https://github.com/rudderlabs/code-server/pull/210)** which is stacked on [#209](https://github.com/rudderlabs/code-server/pull/209). After both upstream PRs merge, GitHub will rebase this PR onto `main` automatically.

## How it works

New workbench contribution at `lib/vscode/src/vs/workbench/contrib/codeServerProfiles/browser/openContextMdContribution.ts`, registered via the modern `registerWorkbenchContribution2(...)` API at `WorkbenchPhase.AfterRestored` (which maps to `LifecyclePhase.Restored` — fires after editor restoration is settled, so we can reliably check whether persisted tabs are open).

Flow on workbench restore:

1. Check workspace-scoped `IStorageService` flag `code-server.profilesContextMd.firstVisitHandled`. If true → exit (one-shot).
2. Set the flag to true **immediately**, before any async work, so a downstream failure cannot retrigger.
3. If `IEditorService.editors.length > 0` → user has restored tabs; exit. Do NOT force the preview open.
4. Require a single-folder workspace (`WorkbenchState.FOLDER`); skip multi-root / empty workspaces.
5. List the workspace folder's root via `IFileService.resolve`, filter for files matching `/_context\.md$/i`, sort alphabetically, take the first.
6. If no match → exit (PRO-5561 will eventually fill the empty editor area with the AI panel).
7. **Activate the markdown extension** — `await extensionService.whenInstalledExtensionsRegistered()` then `await extensionService.activateByEvent('onLanguage:markdown')`. The `markdown.showPreview` command lives in the `markdown-language-features` extension and is only registered after it activates. The extension's activation events (per `extensions/markdown-language-features/package.json`) are `onLanguage:markdown`, `onWebviewPanel:markdown.preview`, and a couple of `onCommand:markdown.api.*` — none of which fire from invoking `markdown.showPreview` itself, so without this explicit activation the command is "not found" on cold-restore and the preview never appears.
8. Open via `ICommandService.executeCommand('markdown.showPreview', uri)` — verified preview-only (no source editor side-effect) by reading the markdown extension's `showPreview.ts`: when called with an explicit URI and no active text editor, the command opens the preview in `vscode.ViewColumn.One` without creating a source editor.

## What changed

- **New patch** `patches/open-context-md-on-first-visit.diff` — adds:
  - New file `lib/vscode/src/vs/workbench/contrib/codeServerProfiles/browser/openContextMdContribution.ts` (~101 lines, contribution class + registration)
  - One-line import in `lib/vscode/src/vs/workbench/workbench.common.main.ts` after the existing `rudderstackTabStatusBar.contribution.js` import added by PR #209
- **Modified** `patches/series` — appends `open-context-md-on-first-visit.diff` between `editor-tab-strip.diff` and `harden-iframe-postmessage.diff`.

## How this was reviewed

Two iterations:

- **Iter-1 (initial implementation)**: dev → QA pass. QA verified all 7 import paths resolve, all 11 symbols are real exports, no unused imports / fields, `markdown.showPreview` is preview-only when passed an explicit URI, `WorkbenchPhase.AfterRestored` correctly fires after editor restoration completes, flag is set before async work, full 42-patch series applies cleanly under `gpatch -p1 -F 2 --no-backup-if-mismatch` (CI-equivalent), no blank-context-line bug.
- **Iter-2 (auto-preview not firing fix)**: Diagnosed root cause directly from VS Code source — `markdown.showPreview` only registers after `markdown-language-features` activates, and its activation events do not include `onCommand:markdown.showPreview`. On a true first visit no source editor is open, so `onLanguage:markdown` has not fired; the command is "not found" and the catch-and-log swallows the failure silently. Fix: explicitly drive the markdown extension's activation via `IExtensionService.activateByEvent('onLanguage:markdown')` before the `executeCommand` call. Single-commit follow-up: [`c39a94b3`](https://github.com/rudderlabs/code-server/pull/211/commits/c39a94b3).

## Visual diff — local capture

Captured locally with this PR's patches applied (`./scripts/code.sh /tmp/code-server-test-ws --user-data-dir=...`). User-data was pre-set with `workbench.startupEditor: 'none'` so no dev-mode Welcome tab competes with the auto-preview.

### AFTER (this PR)

![AFTER — preview auto-opens as the only tab on first workspace visit](https://raw.githubusercontent.com/rudderlabs/code-server/docs/screenshots/pr211/after-annotated.png)

Fresh workspace contained a single top-level `engineering_org_context.md`. On launch:
- `AfterRestored` phase fires the contribution
- Storage flag was unset → proceeds
- `editorService.editors.length === 0` (no persisted tabs) → proceeds
- File matches `_context.md$` → activates markdown extension + invokes `markdown.showPreview`
- Result: the rendered preview opens as the only tab, no source editor side-effect

### Before baseline

Equivalent state on the PR #210 tip (without this PR's contribution) is an empty editor area on first visit. See PR #210's after image as the baseline: [pr210/after-annotated.png](https://raw.githubusercontent.com/rudderlabs/code-server/docs/screenshots/pr210/after-annotated.png).

## Test plan

This patch repo is verified post-merge by bumping the code-server image in the rudder-devops repo. After this PR merges and the image rebuilds, on `app.dev.rudderlabs.com`:

- [ ] Open a brand-new Profiles project (no prior session storage). Confirm `*_context.md` opens as rendered markdown preview as the only tab.
- [ ] Close the preview, reload the page. Confirm it does NOT re-open.
- [ ] Open the same project on a different browser (or after clearing IndexedDB). With `StorageTarget.USER`, the flag may sync via Settings Sync — see open question #1 below.
- [ ] Open a project that has no `*_context.md` at root. Confirm no tab opens, IDE shows empty editor area (PRO-5561 follow-up will fill).
- [ ] Open a project with persisted tabs (re-opening after using). Confirm tabs restore as today, no auto-preview override.
- [ ] If you can drop two `*_context.md`-pattern files at root (e.g. `b_context.md` and `a_context.md`), confirm `a_context.md` wins (alphabetical first).

## Open questions for reviewers

1. **`StorageTarget.USER` vs `StorageTarget.MACHINE`** — the flag is currently `USER` which means it syncs across machines via Settings Sync. Arguable that `MACHINE` is more appropriate.
2. **Flag is burned even when persisted editors block the open** — if a user already has tabs when the workspace is first reached, the flag is set (we skip the open) and the preview will never auto-open in that workspace later. Alternative would be to only set the flag once we actually open the preview.
3. **Logging** — failures in `maybeOpen()` are caught and logged via `console.error`. Switching to `ILogService.error` would match workbench conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
