### PR TITLE
chore: remove GITHUB_PAT from Docker build args

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -425,7 +425,6 @@ jobs:
           labels: ${{ steps.arch-meta.outputs.labels }}
           build-args: |
             TARGETARCH=${{ matrix.arch }}
-            GITHUB_PAT=${{ secrets.PAT }}
           secrets: |
             PYPI_CONNECTION_STRING=admin:${{ secrets.PYPI_PASSWORD }}@pypi.dev-rudder.rudderlabs.com/simple
           cache-from: type=gha


### PR DESCRIPTION
Removed GITHUB_PAT from build arguments in Docker workflow.

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Fixes #
