### PR TITLE
fix: match sidebar, tab, and status bar font sizes to Figma design

### DIFF
--- a/patches/match-figma-font-sizes.diff
+++ b/patches/match-figma-font-sizes.diff
@@ -1,0 +1,113 @@
+Index: code-server/lib/vscode/src/vs/workbench/browser/media/style.css
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/workbench/browser/media/style.css
++++ code-server/lib/vscode/src/vs/workbench/browser/media/style.css
+@@ -28,10 +28,15 @@
+ .monaco-workbench.linux:lang(ja) { font-family: system-ui, "Ubuntu", "Droid Sans", "Source Han Sans J", "Source Han Sans JP", "Source Han Sans", sans-serif; }
+ .monaco-workbench.linux:lang(ko) { font-family: system-ui, "Ubuntu", "Droid Sans", "Source Han Sans K", "Source Han Sans JR", "Source Han Sans", "UnDotum", "FBaekmuk Gulim", sans-serif; }
+ 
++/* Inter font for code-server web */
++@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap');
++
+ .monaco-workbench.mac { --monaco-monospace-font: "SF Mono", Monaco, Menlo, Courier, monospace; }
+ .monaco-workbench.windows { --monaco-monospace-font: Consolas, "Courier New", monospace; }
+ .monaco-workbench.linux { --monaco-monospace-font: "Ubuntu Mono", "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace; }
+ 
++.monaco-workbench.web { font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
++
+ /* Global Styles */
+ 
+ body {
+@@ -46,7 +51,7 @@ body {
+ }
+ 
+ .monaco-workbench {
+-	font-size: 13px;
++	font-size: 12px;
+ 	line-height: 1.4em;
+ 	position: relative;
+ 	z-index: 1;
+Index: code-server/lib/vscode/src/vs/workbench/browser/parts/editor/media/editortabscontrol.css
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/workbench/browser/parts/editor/media/editortabscontrol.css
++++ code-server/lib/vscode/src/vs/workbench/browser/parts/editor/media/editortabscontrol.css
+@@ -22,7 +22,15 @@
+ 
+ .monaco-workbench .part.editor > .content .editor-group-container > .title .title-label a,
+ .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab .tab-label a {
+-	font-size: 13px;
++	font-size: 12px;
++}
++
++/* Figma: active tab Inter Medium, inactive Inter Regular */
++.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active .tab-label a {
++	font-weight: 500;
++}
++.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab:not(.active) .tab-label a {
++	font-weight: 400;
+ }
+ 
+ .monaco-workbench .part.editor > .content .editor-group-container > .title .monaco-icon-label::before,
+Index: code-server/lib/vscode/src/vs/workbench/browser/parts/media/paneCompositePart.css
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/workbench/browser/parts/media/paneCompositePart.css
++++ code-server/lib/vscode/src/vs/workbench/browser/parts/media/paneCompositePart.css
+@@ -67,7 +67,8 @@
+ 	text-transform: uppercase;
+ 	padding-left: 10px;
+ 	padding-right: 10px;
+-	font-size: 11px;
++	font-size: 12px;
++	font-weight: 500;
+ 	padding-bottom: 2px; /* puts the bottom border down */
+ 	padding-top: 2px;
+ 	display: flex;
+@@ -197,11 +198,11 @@
+ .monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .badge .badge-content {
+ 	padding: 3px 5px;
+ 	border-radius: 10px;
+-	font-size: 10px;
++	font-size: 12px;
+ 	min-width: 16px;
+ 	height: 16px;
+-	line-height: 10px;
+-	font-weight: normal;
++	line-height: 12px;
++	font-weight: 500;
+ 	text-align: center;
+ 	display: inline-block;
+ 	box-sizing: border-box;
+Index: code-server/lib/vscode/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
++++ code-server/lib/vscode/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
+@@ -9,6 +9,7 @@
+ 	width: 100%;
+ 	height: 22px;
+ 	font-size: 12px;
++	font-weight: 300;
+ 	display: flex;
+ 	overflow: hidden;
+ }
+Index: code-server/lib/vscode/src/vs/workbench/browser/parts/views/media/paneviewlet.css
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/workbench/browser/parts/views/media/paneviewlet.css
++++ code-server/lib/vscode/src/vs/workbench/browser/parts/views/media/paneviewlet.css
+@@ -13,6 +13,7 @@
+ 
+ .monaco-pane-view .pane > .pane-header {
+ 	position: relative;
++	background: transparent !important; /* Figma: section headers have no separate bg */
+ }
+ 
+ .monaco-pane-view .pane > .pane-header.not-collapsible .twisty-container {
+@@ -43,7 +44,8 @@
+ 	white-space: nowrap;
+ 	text-overflow: ellipsis;
+ 	overflow: hidden;
+-	font-size: 11px;
++	font-size: 12px;
++	font-weight: 500;
+ 	min-width: 3ch;
+ 	-webkit-margin-before: 0;
+ 	-webkit-margin-after: 0;

--- a/patches/series
+++ b/patches/series
@@ -36,3 +36,4 @@ cline-seed-storage.diff
 hide-scm-actions.diff
 hide-scm-title-actions.diff
 harden-iframe-postmessage.diff
+match-figma-font-sizes.diff


### PR DESCRIPTION
## Summary
- Adds new quilt patch `match-figma-font-sizes.diff` that loads **Inter** font via Google Fonts CDN and aligns font size/weight across the UI to the [Figma spec](https://www.figma.com/design/SDpW683dzIqtXeGsAyQqyt/Profiles-%7C-Feb-26th-2026?node-id=162-3059&m=dev)
- **Tabs:** 13px → 12px, active tab weight 500 (Medium), inactive 400 (Regular)
- **Section headers** (PROJECT, OUTLINE, TIMELINE): 11px → 12px + weight 500
- **Panel titles** (CHANGES, etc.): 11px → 12px + weight 500
- **Badges:** 10px → 12px + weight 500
- **Status bar:** adds weight 300 (Light)
- **Base workbench font:** 13px → 12px, with `.web` selector setting Inter as primary font-family

## Test plan
- [ ] Build code-server and open in browser
- [ ] Verify Inter loads from Google Fonts CDN (Network tab)
- [ ] Check tabs render at 12px with active/inactive weight differentiation
- [ ] Check sidebar section headers and panel titles at 12px Medium
- [ ] Check badges at 12px Medium — no overflow
- [ ] Check status bar at 12px Light (300)
- [ ] Verify commit input and buttons remain at 13px (unaffected by base change)
- [ ] Test with CDN blocked — fallback fonts should render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)