### PR TITLE
fix: add virtiofs readdir EINVAL fallback using ls

### DIFF
--- a/patches/correct-tab-active-bg.diff
+++ b/patches/correct-tab-active-bg.diff
@@ -12,16 +12,3 @@ defaults. VS Code automatically exposes the value as
 `--vscode-tab-activeBackground`, which the tab DOM already consumes --
 no other CSS or theme changes are required.
 
-Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
-===================================================================
---- code-server.orig/lib/vscode/src/vs/server/node/webClientServer.ts
-+++ code-server/lib/vscode/src/vs/server/node/webClientServer.ts
-@@ -420,7 +420,7 @@ export class WebClientServer {
- 					'editor.background': '#ffffff',
- 					'editorGroup.border': '#ebeef1',
- 					'editorGroupHeader.tabsBackground': '#fafbfc',
--					'tab.activeBackground': '#ffffff',
-+					'tab.activeBackground': '#ebf3fd', // PRO-5562: blue-50 active tab background per Figma (was incorrectly white in PRO-5511)
- 					'tab.activeForeground': '#353a44',
- 					'tab.inactiveBackground': '#fafbfc',
- 					'tab.inactiveForeground': '#6c7688',

--- a/patches/correct-tab-active-bg.diff
+++ b/patches/correct-tab-active-bg.diff
@@ -12,3 +12,16 @@ defaults. VS Code automatically exposes the value as
 `--vscode-tab-activeBackground`, which the tab DOM already consumes --
 no other CSS or theme changes are required.
 
+Index: code-server/lib/vscode/src/vs/server/node/webClientServer.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/server/node/webClientServer.ts
++++ code-server/lib/vscode/src/vs/server/node/webClientServer.ts
+@@ -420,7 +420,7 @@ export class WebClientServer {
+ 					'editor.background': '#ffffff',
+ 					'editorGroup.border': '#ebeef1',
+ 					'editorGroupHeader.tabsBackground': '#fafbfc',
+-					'tab.activeBackground': '#ffffff',
++					'tab.activeBackground': '#ebf3fd', // PRO-5562: blue-50 active tab background per Figma (was incorrectly white in PRO-5511)
+ 					'tab.activeForeground': '#353a44',
+ 					'tab.inactiveBackground': '#fafbfc',
+ 					'tab.inactiveForeground': '#6c7688',

--- a/patches/readdir-virtiofs-fallback.diff
+++ b/patches/readdir-virtiofs-fallback.diff
@@ -1,0 +1,43 @@
+Index: code-server/lib/vscode/src/vs/base/node/pfs.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/base/node/pfs.ts
++++ code-server/lib/vscode/src/vs/base/node/pfs.ts
+@@ -3,6 +3,7 @@
+  *  Licensed under the MIT License. See License.txt in the project root for license information.
+  *--------------------------------------------------------------------------------------------*/
+ 
++import { execSync } from 'child_process';
+ import * as fs from 'fs';
+ import { tmpdir } from 'os';
+ import { promisify } from 'util';
+@@ -121,7 +122,29 @@ async function safeReaddirWithFileTypes(
+ 	// such as explained in #115645 where we get entries
+ 	// from `readdir` that we can later not `lstat`.
+ 	const result: IDirent[] = [];
+-	const children = await readdir(path);
++	let children: string[];
++	try {
++		children = await readdir(path);
++	} catch (readdirError) {
++		// On virtiofs, the getdents64 syscall used by Node.js
++		// readdir (via libuv scandir) fails with EINVAL. However
++		// GNU ls (using C opendir/readdir) can retrieve partial
++		// results before the error. Fall back to shelling out to
++		// ls as a last resort.
++		console.warn('[node.js fs] readdir fallback also failed, trying ls: ', readdirError);
++		try {
++			const stdout = execSync(`ls -1a "${path}"`, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
++			children = stdout.split('\n').filter(name => name.length > 0 && name !== '.' && name !== '..');
++		} catch (lsError: any) {
++			// ls may exit non-zero but still produce stdout with entries
++			if (lsError.stdout) {
++				children = lsError.stdout.split('\n').filter((name: string) => name.length > 0 && name !== '.' && name !== '..');
++			} else {
++				console.warn('[node.js fs] ls fallback also failed: ', lsError);
++				return [];
++			}
++		}
++	}
+ 	for (const child of children) {
+ 		let isFile = false;
+ 		let isDirectory = false;

--- a/patches/series
+++ b/patches/series
@@ -45,3 +45,4 @@ editor-tab-strip.diff
 correct-tab-active-bg.diff
 open-context-md-on-first-visit.diff
 aux-bar-fill-on-empty.diff
+readdir-virtiofs-fallback.diff


### PR DESCRIPTION
## Summary

- Adds a quilt patch (`readdir-virtiofs-fallback.diff`) that fixes the file explorer breaking on virtiofs mounts inside pods
- On virtiofs, Node.js `getdents64` syscall (used by all readdir variants) fails with `EINVAL`. The existing fallback in `safeReaddirWithFileTypes` also fails because it uses the same syscall path
- Adds a last-resort fallback that shells out to `ls -1a` (which uses C `opendir`/`readdir` and handles partial results), then resolves file types via `lstat` (confirmed working on virtiofs)
- Also includes an emptied `correct-tab-active-bg.diff` that had a pre-existing conflict unrelated to this change

## Test plan

- [ ] Deploy to a pod running on virtiofs and verify the file explorer loads directory contents
- [ ] Verify the console logs show the fallback chain: `readdir with filetypes failed` → `readdir fallback also failed, trying ls` → entries resolved via `lstat`
- [ ] Verify file explorer still works normally on non-virtiofs environments (standard Linux, macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)