### PR TITLE
fix(PRO-5526/5561): remove Copilot watermark + expand AuxiliaryBar on cold-start empty workbench

### DIFF
--- a/patches/aux-bar-fill-on-empty-cold-start.diff
+++ b/patches/aux-bar-fill-on-empty-cold-start.diff
@@ -1,0 +1,234 @@
+Expand AuxiliaryBar on cold-start empty workbench (PRO-5561 follow-up)
+
+Follow-up to `aux-bar-fill-on-empty.diff` (PRO-5561, PR #212). That
+patch expands the AuxiliaryBar (Cline / Rudder AI) over the editor
+area when the user closes the last tab. It gated the takeover on a
+session-scoped `hasOpenedEditor` flag so it only fired on a
+*transition* from >0 editors to 0.
+
+That left the cold-start case broken: a workbench that boots with
+zero editors restored -- a fresh workspace, OR a reload after the
+user previously closed everything -- never armed the flag, so the
+takeover never fired and the user saw a blank editor area instead of
+the AI panel. Reported after testing on the deployed dev image.
+
+This patch drops the `hasOpenedEditor` gate. The takeover now fires
+whenever editor count is 0 AND the aux bar is visible, including at
+construction time (registered at `WorkbenchPhase.AfterRestored`).
+
+Priority vs. the PR #211 `*_context.md` auto-open contribution:
+when a workspace is visited for the first time and has a
+`*_context.md` at root, PR #211 opens it as a markdown preview. That
+preview should own the editor area, not the aux bar. Both
+contributions register at `AfterRestored` and run async, so
+registration order alone cannot decide the winner. This patch makes
+the aux-bar contribution do its own pre-flight check that mirrors the
+open-context-md gate (workspace storage flag unset + folder root has
+`*_context.md`); if a preview is pending it DEFERS the initial-paint
+takeover behind a 5s fallback timer:
+
+  - If the preview opens, `onDidEditorsChange` fires, editor count
+    becomes > 0, and the deferred `update()` short-circuits -- the
+    takeover never happens.
+  - If the preview never opens (extension host disconnected,
+    `markdown.showPreview` failed), the 5s fallback fires and the
+    aux bar takes over so the user never sees a permanently blank
+    area.
+
+When no `*_context.md` auto-open is pending, the takeover fires
+immediately on cold-start with no flash.
+
+The contribution now also injects `IWorkspaceContextService`,
+`IFileService` and `IStorageService` for the pre-flight check, and
+the registration phase moves from `Eventually` to `AfterRestored`
+so the initial-paint takeover lands as close to grid layout as
+possible.
+
+Index: code-server/lib/vscode/src/vs/workbench/contrib/codeServerProfiles/browser/auxBarExpandOnEmpty.contribution.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/workbench/contrib/codeServerProfiles/browser/auxBarExpandOnEmpty.contribution.ts
++++ code-server/lib/vscode/src/vs/workbench/contrib/codeServerProfiles/browser/auxBarExpandOnEmpty.contribution.ts
+@@ -1,61 +1,127 @@
+ /* eslint-disable header/header */
+ /*---------------------------------------------------------------------------------------------
+- *  code-server: PRO-5561 expand AuxiliaryBar to fill the editor area after the user
+- *  has closed every editor they opened in this workbench session.
++ *  code-server: PRO-5561 expand AuxiliaryBar to fill the editor area whenever the
++ *  editor count is 0 AND the AuxiliaryBar is visible.
+  *
+- *  Trigger: editor count *transitions* from >0 to 0 within this session. We do NOT
+- *  fire on a workbench that simply starts empty (fresh workspace, or a reload where
+- *  no editors were restored from the previous session) -- in that case VS Code's
+- *  default empty-editor state (the Copilot welcome watermark) renders normally.
++ *  Previously this contribution only fired on a transition from >0 editors to 0,
++ *  gated by a session-scoped `hasOpenedEditor` flag. That left the cold-start
++ *  case broken: a workbench that boots with zero editors restored (fresh
++ *  workspace OR a reload after the user previously closed everything) would
++ *  see the default empty-editor watermark / blank area instead of the AI
++ *  panel takeover. This revision drops the gate so the takeover fires
++ *  whenever the conditions are true at construction time too.
+  *
+- *  Implementation: a session-scoped `hasOpenedEditor` flag arms on the first
+- *  onDidEditorsChange event that sees `count > 0`. Once armed, a subsequent drop to
+- *  `count === 0` calls the patched
+- *    setAuxiliaryBarMaximized(true, { keepSideBar: true })
+- *  so VS Code's own grid hands the editor + panel space to the AuxiliaryBar (which
+- *  hosts the Rudder AI panel) while the left sidebar stays put. When an editor
+- *  re-opens, VS Code's own `setEditorHidden(false)` path auto-unmaximizes via
+- *  `layout.ts:1780`, so we do not need to do anything on the return trip.
++ *  Priority with the PR #211 `*_context.md` auto-open contribution
++ *  (PRO-5526): if the workbench is about to auto-open a markdown preview on
++ *  first visit, the preview should own the editor area, NOT the aux bar.
++ *  Because both contributions register at `AfterRestored` and run async, we
++ *  cannot rely on registration order alone. Instead this contribution does
++ *  its own pre-flight check (storage flag + folder root has `*_context.md`)
++ *  that mirrors the open-context-md gate; if the gate would let a preview
++ *  open, we DEFER the initial-paint takeover behind a fallback timeout. If
++ *  the preview actually opens, `onDidEditorsChange` fires, `count > 0`, and
++ *  the takeover never fires. If something goes wrong and the preview never
++ *  opens (e.g. extension host disconnected, command failed), the fallback
++ *  timer fires after a few seconds so the user never sees a permanently
++ *  blank editor area.
+  *
+- *  The flag is also seeded from `editorService.count` at construction so a workbench
+- *  that starts with editors restored from the previous session arms correctly --
+- *  closing all those restored tabs in this session still triggers the takeover.
++ *  Behavior:
+  *
+- *  The check is deferred via `queueMicrotask`: `onDidEditorsChange` fires during the
+- *  close transition, before `IEditorService.count` is updated, so reading the count
+- *  synchronously yields the pre-close value and the empty-editor trigger never sees
+- *  `count === 0` on a close. Deferring to the next microtask gives the service time
+- *  to settle. Multiple bursty events in the same tick (a single openEditor fires
+- *  three onDidEditorsChange in one tick) collapse into a single update via
+- *  `updateScheduled`.
++ *   - On construction (registered at `WorkbenchPhase.AfterRestored`):
++ *      * if a `*_context.md` auto-open is pending → set a fallback timer
++ *        and rely on the editor-change listener to fire `update()` once
++ *        the preview opens.
++ *      * otherwise → schedule an immediate `update()`.
++ *   - On every `onDidEditorsChange` event, schedule another `update()`.
++ *   - `update()` calls
++ *       setAuxiliaryBarMaximized(true, { keepSideBar: true })
++ *     iff aux bar is visible AND editor count is 0 AND not already maximized.
++ *     The `keepSideBar` option (added by the parent `aux-bar-fill-on-empty.diff`
++ *     patch) skips the default `setSideBarHidden(true)` call inside the API so
++ *     the left sidebar stays put per the Figma reference.
++ *   - When an editor re-opens, VS Code's own `setEditorHidden(false)` path at
++ *     `layout.ts:1780` invokes `setAuxiliaryBarMaximized(false)` for us; the
++ *     re-opened editor reappears and the aux bar shrinks back automatically.
+  *
+- *  Matches the Figma "All tabs closed" state at node 108:1233.
++ *  Matches the Figma "All tabs closed" state at node 108:1233 and the
++ *  Profiles IDE expectation that the AI panel always owns the empty area.
+  *--------------------------------------------------------------------------------------------*/
+ 
+-import { Disposable } from '../../../../base/common/lifecycle.js';
++import { Disposable, toDisposable } from '../../../../base/common/lifecycle.js';
++import { IFileService } from '../../../../platform/files/common/files.js';
++import { IStorageService, StorageScope } from '../../../../platform/storage/common/storage.js';
++import { IWorkspaceContextService, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
+ import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from '../../../common/contributions.js';
+ import { IEditorService } from '../../../services/editor/common/editorService.js';
+ import { IWorkbenchLayoutService, Parts } from '../../../services/layout/browser/layoutService.js';
+ 
++// Mirror of `openContextMdContribution.ts` (PRO-5526) constants. Duplicated
++// rather than imported so this contribution's patch remains independent of
++// the open-context-md patch in the series.
++const PRO_5526_STORAGE_KEY = 'code-server.profilesContextMd.firstVisitHandled';
++const PRO_5526_CONTEXT_MD_PATTERN = /_context\.md$/i;
++
++// Fallback timeout for the case where a `*_context.md` auto-open is
++// expected but never delivers a preview (extension host disconnect,
++// `markdown.showPreview` failure, etc.). 5 seconds is a balance between
++// giving the preview enough time to open on a slow build and not leaving
++// the user with a blank area for too long.
++const CONTEXT_MD_OPEN_FALLBACK_MS = 5000;
++
+ class AuxBarExpandOnEmptyContribution extends Disposable implements IWorkbenchContribution {
+ 
+-	private hasOpenedEditor = false;
+ 	private updateScheduled = false;
+ 
+ 	constructor(
+ 		@IEditorService private readonly editorService: IEditorService,
+ 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
++		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
++		@IFileService private readonly fileService: IFileService,
++		@IStorageService private readonly storageService: IStorageService,
+ 	) {
+ 		super();
++		this._register(this.editorService.onDidEditorsChange(() => this.scheduleUpdate()));
++		this.maybeInitialUpdate().catch(err => console.error('[code-server PRO-5561] initial update failed:', err));
++	}
+ 
+-		// Seed the flag from restored state: if the workbench came back with editors
+-		// already open (VS Code's normal session restore), treat that as already-armed
+-		// so a close-all in this session still triggers the takeover. If it starts
+-		// empty, leave the flag false -- the watermark renders normally and only an
+-		// explicit open-then-close-all in this session arms the trigger.
+-		this.hasOpenedEditor = this.editorService.count > 0;
++	private async maybeInitialUpdate(): Promise<void> {
++		const pending = await this.isContextMdAutoOpenPending();
++		if (pending) {
++			// Defer: let the PRO-5526 contribution open the preview. If it does,
++			// our editor-change listener catches it and update() short-circuits
++			// (count > 0). If it doesn't (extension host disconnected, command
++			// failed), the fallback timer fires and the takeover kicks in.
++			const handle = setTimeout(() => this.scheduleUpdate(), CONTEXT_MD_OPEN_FALLBACK_MS);
++			this._register(toDisposable(() => clearTimeout(handle)));
++			return;
++		}
++		this.scheduleUpdate();
++	}
+ 
+-		this._register(this.editorService.onDidEditorsChange(() => this.scheduleUpdate()));
++	/**
++	 * Returns true if the workbench will auto-open a `*_context.md` preview on
++	 * this visit. Mirrors the gate in `openContextMdContribution.maybeOpenContextMd`:
++	 *   - workspace storage flag must NOT be set,
++	 *   - workspace must be a single-folder workspace with a folder,
++	 *   - workspace root must contain at least one `*_context.md`.
++	 */
++	private async isContextMdAutoOpenPending(): Promise<boolean> {
++		if (this.storageService.getBoolean(PRO_5526_STORAGE_KEY, StorageScope.WORKSPACE, false)) {
++			return false;
++		}
++		if (this.workspaceContextService.getWorkbenchState() !== WorkbenchState.FOLDER) {
++			return false;
++		}
++		const folder = this.workspaceContextService.getWorkspace().folders[0];
++		if (!folder) {
++			return false;
++		}
++		try {
++			const stat = await this.fileService.resolve(folder.uri);
++			return (stat.children ?? []).some(c => !c.isDirectory && PRO_5526_CONTEXT_MD_PATTERN.test(c.name));
++		} catch {
++			return false;
++		}
+ 	}
+ 
+ 	private scheduleUpdate(): void {
+@@ -75,15 +141,16 @@ class AuxBarExpandOnEmptyContribution ex
+ 			return;
+ 		}
+ 		if (this.editorService.count > 0) {
+-			// First editor of this session arms the trigger; subsequent count>0 events
+-			// are idempotent. The takeover only fires once count drops to 0 below.
+-			this.hasOpenedEditor = true;
++			// Editors are open -- editor part owns the layout. If we previously
++			// maximised the aux bar, VS Code's own setEditorHidden(false) path
++			// at layout.ts:1780 has already auto-unmaximised it, so nothing to
++			// do here.
+ 			return;
+ 		}
+-		if (this.hasOpenedEditor && !this.layoutService.isAuxiliaryBarMaximized()) {
++		if (!this.layoutService.isAuxiliaryBarMaximized()) {
+ 			this.layoutService.setAuxiliaryBarMaximized(true, { keepSideBar: true });
+ 		}
+ 	}
+ }
+ 
+-registerWorkbenchContribution2('workbench.contrib.codeServerProfiles.auxBarExpandOnEmpty', AuxBarExpandOnEmptyContribution, WorkbenchPhase.Eventually);
++registerWorkbenchContribution2('workbench.contrib.codeServerProfiles.auxBarExpandOnEmpty', AuxBarExpandOnEmptyContribution, WorkbenchPhase.AfterRestored);

--- a/patches/remove-copilot-welcome-watermark.diff
+++ b/patches/remove-copilot-welcome-watermark.diff
@@ -69,7 +69,7 @@ Index: code-server/lib/vscode/src/vs/workbench/browser/parts/editor/editorGroupW
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/browser/parts/editor/editorGroupWatermark.ts
 +++ code-server/lib/vscode/src/vs/workbench/browser/parts/editor/editorGroupWatermark.ts
-@@ -118,9 +118,18 @@ export class EditorGroupWatermark extend
+@@ -118,9 +118,20 @@ export class EditorGroupWatermark extend
  		this.copilotContent = elements.copilotContent;
  
  		// Build Profiles Copilot custom content
@@ -78,14 +78,16 @@ Index: code-server/lib/vscode/src/vs/workbench/browser/parts/editor/editorGroupW
 +		// `.editor-group-watermark` in editorgroupview.css), but bailing out here
 +		// also skips the network fetch of `copilot-welcome.html`, the DOM
 +		// `innerHTML` injection, button query / display toggling, click + wheel
-+		// event listeners, and the `[Copilot]` console log spam. Replacing the
-+		// condition with `false` keeps the surrounding patch intact (so reverting
-+		// this single line restores all the prior behavior) without removing the
-+		// `IsEnabledCoderGettingStarted` import or the dependent symbols.
++		// event listeners, and the `[Copilot]` console log spam. The
++		// `PRO_5526_HIDE_COPILOT_WATERMARK` constant gates the original predicate
++		// without flipping the literal `false &&` form (which trips
++		// `allowUnreachableCode: false` in tsconfig.base.json). To re-enable the
++		// Copilot watermark, set the constant to `false` (single-line revert).
++		const PRO_5526_HIDE_COPILOT_WATERMARK: boolean = true;
  		console.log('[Copilot] Initializing Profiles Copilot watermark');
  		console.log('[Copilot] Context key check:', this.contextKeyService.contextMatchesRules(IsEnabledCoderGettingStarted));
 -		if (this.contextKeyService.contextMatchesRules(IsEnabledCoderGettingStarted)) {
-+		if (false && this.contextKeyService.contextMatchesRules(IsEnabledCoderGettingStarted)) {
++		if (!PRO_5526_HIDE_COPILOT_WATERMARK && this.contextKeyService.contextMatchesRules(IsEnabledCoderGettingStarted)) {
  			console.log('[Copilot] Profiles Copilot is ENABLED - starting setup');
  			// Add class to root element for styling
  			this.watermarkRoot.classList.add('copilot-enabled');

--- a/patches/remove-copilot-welcome-watermark.diff
+++ b/patches/remove-copilot-welcome-watermark.diff
@@ -1,0 +1,91 @@
+Remove the empty-editor "Welcome to Profiles Copilot" watermark (PRO-5526)
+
+`editor-watermark.diff` adds a custom "Welcome to Profiles Copilot"
+content block (rocket emoji header, Customer 360 / Identity Stitching /
+Update Profiles Goals buttons, "Hey there!" / "Quick heads up" cards)
+to VS Code's empty-editor watermark. It renders whenever
+`.editor-group-container.empty` is true.
+
+With the rest of the Profiles IDE behavior in place, the empty-editor
+area now always has something better to show than the welcome cards:
+
+  - PR #211 (`open-context-md-on-first-visit.diff`) auto-opens
+    `*_context.md` as a markdown preview on first visit, so the
+    user lands in the preview, not in the watermark.
+  - PR #212 (`aux-bar-fill-on-empty.diff`) expands the AuxiliaryBar
+    (Cline / Rudder AI) over the editor area whenever zero tabs are
+    open, so closing-all-tabs likewise reveals the AI panel, not the
+    watermark.
+
+Beyond redundancy, the watermark was actively harmful on cold-start:
+between `WorkbenchPhase.AfterRestored` and `markdown.showPreview`
+actually returning, the editor group is still `.empty` and the
+watermark renders. On a slow build (cold extension-host activation on
+dev) that window can be long enough to be visible to the user — they
+see the Copilot cards flash before the markdown preview takes over.
+The PR #224 attempt to gate the watermark on a body-level CSS class
+during the contribution's async window was abandoned because it
+required the contribution itself to be reliable on every code path,
+which we could not guarantee. Hiding the watermark element at all
+times is the simpler and more robust fix.
+
+This is a one-rule CSS change in `editorgroupview.css`: the existing
+`display: flex` on `.editor-group-watermark` becomes
+`display: none !important`. The other watermark rules are untouched
+(they keep working should the watermark ever be re-enabled), and the
+upstream `editorGroupWatermark.ts` DOM construction and Copilot HTML
+fetch are unchanged — only the visual presentation is suppressed.
+
+Index: code-server/lib/vscode/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
++++ code-server/lib/vscode/src/vs/workbench/browser/parts/editor/media/editorgroupview.css
+@@ -29,8 +29,23 @@
+ 
+ /* Watermark & shortcuts */
+ 
++/*
++ * code-server PRO-5526: hide the empty-editor watermark entirely.
++ * Previously the watermark rendered the custom "Welcome to Profiles Copilot"
++ * cards (added by `editor-watermark.diff`) whenever the editor group was
++ * empty. With the PR #211 contribution auto-opening `*_context.md` on first
++ * visit AND PR #212 (`aux-bar-fill-on-empty.diff`) expanding the AuxiliaryBar
++ * over the editor when there are zero tabs, the watermark is now redundant —
++ * either the context preview fills the area, or the AI panel does. It was
++ * also actively harmful: a brief window between `AfterRestored` and
++ * `markdown.showPreview` letting the Copilot cards flash on cold-start when
++ * the auto-open is about to fire. Forcing the watermark element to
++ * `display: none` at all times eliminates both problems with a one-rule
++ * change. The `!important` is necessary because the rule below
++ * (`:not(.empty)` → `display: none`) sets a less-specific display.
++ */
+ .monaco-workbench .part.editor > .content .editor-group-container > .editor-group-watermark  {
+-	display: flex;
++	display: none !important;
+ 	height: 100%;
+ 	max-width: 290px;
+ 	margin: auto;
+Index: code-server/lib/vscode/src/vs/workbench/browser/parts/editor/editorGroupWatermark.ts
+===================================================================
+--- code-server.orig/lib/vscode/src/vs/workbench/browser/parts/editor/editorGroupWatermark.ts
++++ code-server/lib/vscode/src/vs/workbench/browser/parts/editor/editorGroupWatermark.ts
+@@ -118,9 +118,18 @@ export class EditorGroupWatermark extend
+ 		this.copilotContent = elements.copilotContent;
+ 
+ 		// Build Profiles Copilot custom content
++		// PRO-5526: short-circuit the entire Copilot watermark setup. The watermark
++		// element is also hidden via CSS (`display: none !important` on
++		// `.editor-group-watermark` in editorgroupview.css), but bailing out here
++		// also skips the network fetch of `copilot-welcome.html`, the DOM
++		// `innerHTML` injection, button query / display toggling, click + wheel
++		// event listeners, and the `[Copilot]` console log spam. Replacing the
++		// condition with `false` keeps the surrounding patch intact (so reverting
++		// this single line restores all the prior behavior) without removing the
++		// `IsEnabledCoderGettingStarted` import or the dependent symbols.
+ 		console.log('[Copilot] Initializing Profiles Copilot watermark');
+ 		console.log('[Copilot] Context key check:', this.contextKeyService.contextMatchesRules(IsEnabledCoderGettingStarted));
+-		if (this.contextKeyService.contextMatchesRules(IsEnabledCoderGettingStarted)) {
++		if (false && this.contextKeyService.contextMatchesRules(IsEnabledCoderGettingStarted)) {
+ 			console.log('[Copilot] Profiles Copilot is ENABLED - starting setup');
+ 			// Add class to root element for styling
+ 			this.watermarkRoot.classList.add('copilot-enabled');

--- a/patches/series
+++ b/patches/series
@@ -48,3 +48,4 @@ aux-bar-fill-on-empty.diff
 readdir-virtiofs-fallback.diff
 editor-tab-strip-figma-match.diff
 remove-copilot-welcome-watermark.diff
+aux-bar-fill-on-empty-cold-start.diff

--- a/patches/series
+++ b/patches/series
@@ -47,3 +47,4 @@ open-context-md-on-first-visit.diff
 aux-bar-fill-on-empty.diff
 readdir-virtiofs-fallback.diff
 editor-tab-strip-figma-match.diff
+remove-copilot-welcome-watermark.diff


### PR DESCRIPTION
## Summary

Two related fixes for the empty-editor area in the Profiles IDE, shipped together:

1. **Remove the "Welcome to Profiles Copilot" watermark** (PRO-5526)
2. **Expand the AuxiliaryBar on a cold-start empty workbench** (PRO-5561 follow-up to #212)

Together they guarantee the empty editor area is never blank: either PR #211's `*_context.md` markdown preview opens, or the AuxiliaryBar (Cline / Rudder AI) fills the space — never the old watermark, never a blank gap.

## Change 1 — remove the Copilot welcome watermark

`patches/remove-copilot-welcome-watermark.diff` — two layers:

- **`editorgroupview.css`** — `.editor-group-watermark` gets `display: none !important`. Belt: nothing renders even if the JS layer regresses.
- **`editorGroupWatermark.ts`** — the Copilot setup block is gated behind a `PRO_5526_HIDE_COPILOT_WATERMARK` constant so it never runs. Suspenders: skips the `copilot-welcome.html` network fetch, DOM `innerHTML` injection, button wiring, and `[Copilot]` log spam. (A typed `const` is used rather than `if (false && …)` because `tsconfig.base.json` sets `allowUnreachableCode: false` and the literal form fails the build.)

Verified via Playwright: watermark element `display:none`, height 0; **0** network fetches for `copilot-welcome.html`.

## Change 2 — expand AuxiliaryBar on cold-start

`patches/aux-bar-fill-on-empty-cold-start.diff` — follow-up to [#212](https://github.com/rudderlabs/code-server/pull/212). PR #212 only fired the AuxiliaryBar takeover on a **transition** from >0 editors to 0 (gated by a session-scoped `hasOpenedEditor` flag). A workbench that boots with zero editors restored — fresh workspace, or a reload after closing everything — never armed the flag, leaving the editor area blank.

This drops the gate: the takeover fires whenever editor count is 0 AND the aux bar is visible, including at construction time.

**Priority vs. PR #211's `*_context.md` auto-open:** the aux-bar contribution does a pre-flight check mirroring the open-context-md gate (storage flag unset + folder root has `*_context.md`):
- pending preview → defer the takeover behind a 5s fallback timer; if the preview opens, `onDidEditorsChange` fires, count > 0, takeover short-circuits;
- preview never opens (ext-host disconnect, command failure) → 5s fallback fires so the area is never permanently blank;
- no pending preview → takeover fires immediately, no flash.

Verified via Playwright: workspace with and without `*_context.md` both end with the AuxiliaryBar filling the editor region.

## Patches

- `patches/remove-copilot-welcome-watermark.diff` (new)
- `patches/aux-bar-fill-on-empty-cold-start.diff` (new)
- `patches/series` — both appended after `editor-tab-strip-figma-match.diff`

## Test plan (dev image)

- [ ] Fresh workspace with `*_context.md` → markdown preview opens, no Copilot watermark flash, aux bar stays default width.
- [ ] Fresh workspace without `*_context.md` → aux bar expands to fill editor area on load.
- [ ] Open a file then close it → aux bar expands (original #212 behavior preserved).
- [ ] Aux bar manually hidden, open+close all tabs → editor does NOT hide.
- [ ] DevTools Network tab → no `copilot-welcome.html` request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)