### PR TITLE
fix(PRO-5787): allow rm in lshell to enable file deletion in terminal

### DIFF
--- a/config/lshell.conf
+++ b/config/lshell.conf
@@ -31,7 +31,11 @@ home_path       : '/home/codeuser/project'
 # git - Version control (for users to commit changes)
 # ssh - Required by git for SSH transport (push/pull via sshpiper proxy)
 # echo/whoami/id - Debugging utilities
-allowed         : ['pb', 'pb *', 'pb version *', 'pb run *', 'pb show *', 'pb init *', 'pb compile *', 'pb build *', 'pb audit *', 'pb cleanup *', 'pb discover *', 'pb help *', 'pb migrate *', 'pb query *', 'pb validate *', 'ls', 'cd', 'pwd', 'cat', 'head', 'tail', 'grep', 'find', 'which', 'git', 'ssh', 'echo', 'whoami', 'id']
+# rm/rm * - File deletion (e.g. `rm -rf migrations`) for users and the Cline
+#   agent, which spawns lshell directly via node-pty. Stays scoped to the
+#   project tree: home_path jails navigation to /home/codeuser/project and the
+#   forbidden list below still blocks command chaining / redirection.
+allowed         : ['pb', 'pb *', 'pb version *', 'pb run *', 'pb show *', 'pb init *', 'pb compile *', 'pb build *', 'pb audit *', 'pb cleanup *', 'pb discover *', 'pb help *', 'pb migrate *', 'pb query *', 'pb validate *', 'ls', 'cd', 'pwd', 'cat', 'head', 'tail', 'grep', 'find', 'which', 'git', 'ssh', 'echo', 'whoami', 'id', 'rm', 'rm *']
 
 # ============================================
 # FORBIDDEN COMMANDS (Blacklist)


### PR DESCRIPTION
## What

Adds `rm`/`rm *` to the lshell `allowed` whitelist in `config/lshell.conf` so users can delete files/directories from the terminal (e.g. `rm -rf migrations`).

Closes PRO-5787.

## Why

The terminal runs under **lshell** with `strict=1`, meaning only whitelisted commands execute — everything else is implicitly blocked. `rm` wasn't on the list, so `rm -rf …` failed.

This also affects the **Cline AI agent**, which (per `Dockerfile:18`) spawns lshell directly via node-pty for terminal commands — so it was blocked on the same root cause. This PR fixes both the terminal and the AI-via-terminal paths.

> **Note — File Explorer path:** code-server's right-click → Delete uses the Node `fs` layer directly, *not* lshell, so it is **not** covered by this change. If that path is still broken it's a separate root cause (likely file ownership/permissions) and should be tracked/fixed independently. Tagging here for visibility.

## Security

`rm` re-introduces destructive deletion in an otherwise locked-down container, so this was a deliberate trade-off. It stays well-contained:

- **Path jail:** lshell blocks absolute paths outside `home_path` (`/home/codeuser/project`) by default — verified `rm` on an outside path returns `forbidden path`.
- **No chaining/redirection:** the `forbidden` list (`;`, `|`, `&&`, `>`, …) still applies — verified `rm x ; …` and `rm x | …` return `forbidden syntax`.
- Whitelist semantics unchanged for everything else (e.g. `mv`, `cp`, shells remain blocked).

## Testing

Validated locally against `limited-shell==0.10.1` (same version as `Dockerfile:20`) using a sandbox `home_path`:

| Case | Expected | Result |
|------|----------|--------|
| `rm -rf migrations` (in project) | deletes | ✅ dir removed |
| `mv` (unlisted) | blocked | ✅ `forbidden command -> "mv"` |
| `rm x ; echo` (chaining) | blocked | ✅ `forbidden syntax` |
| `rm x \| cat` (pipe) | blocked | ✅ `forbidden syntax` |
| `rm -rf /tmp/outside` (out of jail) | blocked | ✅ `forbidden path`, file survived |

Config syntax also passes the `configparser` check from `Dockerfile:24`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)